### PR TITLE
Fixes bugs and warnings.  Specific fixes include https://github.com/A…

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -34,12 +34,20 @@
 
 
 ifndef CXX
-  CXX=g++ # Code uses GCC builtins.  I do not recommend changing the compiler.
+  CXX=g++ # Code uses GCC builtins.  I recommend using either g++ or clang++.  
+          # GCC's g++ is probably preferred since it appears to yield better 
+	  # throughput numbers.  However, the results are roughly comparable.
 endif
+
+# Comment the line below back in if you want to instrument the code with the 
+# sanitizer functionality
+#SANITIZE:=-fsanitize=address,undefined,leak
 
 OPT=-Ofast -march=native -mpopcnt 
 
-FLAGS:=-Wall -Winline -g -std=c++11 $(OPT)
+FLAGS:=-Wall -Winline -g -std=c++11 $(OPT) $(SANITIZE)
+
+# Need to routinely check for bugs with -fsanitize=address -fsanitize=undefined
 
 TARGETS=benchmark \
   benchmark_cf benchmark_mf \

--- a/bf.h
+++ b/bf.h
@@ -60,7 +60,7 @@ namespace BlockedBF{
     inline bool contains_and_update(const hash_t item){
       constexpr slot_type one = 1;
       constexpr slot_type slot_width_bits = sizeof(slot_type) * 8;
-      constexpr slot_type log2_slot_width = log2(slot_width_bits);
+      constexpr slot_type log2_slot_width = util::log2ceil(slot_width_bits);
       constexpr slot_type shift0 = 0;
       constexpr slot_type shift1 = log2_slot_width;
       constexpr slot_type shift2 = log2_slot_width * 2;

--- a/block.h
+++ b/block.h
@@ -413,7 +413,6 @@ struct Block{ // Assuming block size is a multiple of atom_t's size in bytes
       memcpy(source_address, &item, field_width_bytes);
     }
 
-    __attribute__((optimize("unroll-loops")))
     INLINE void add_cross_left_displace(uint64_t raw_offset_bits, 
       uint64_t field_width_bits, uint64_t index, atom_t item){
       uint64_t global_index = index * field_width_bits + raw_offset_bits;

--- a/util.h
+++ b/util.h
@@ -74,7 +74,8 @@ namespace util{
   // This could be implemented using fancy binary arithmatic or builtins, 
   // but this probably suffices if the integer is known at compile time.
   constexpr inline uint32_t log2ceil(uint32_t integer){
-    //return ceil(log2(integer));
+    // I'm doing it this way because log2 is not a constexpr function in the 
+    // Clang toolchain whereas __builtin_clz is.
     return 32u - __builtin_clz(integer - 1u);
   }
 


### PR DESCRIPTION
…MDComputeLibraries/morton_filter/issues/2#issue-481752415, replacing use of cmath's log2 in the codebase with a constexpr function as Clang's log2 implementation is not constexpr, minor fixes to address warnings about constexpr class methods, among others.